### PR TITLE
Create dead letter consumer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [com.datomic/datomic-free "0.9.5697"]
                  [nubank/matcher-combinators "3.5.0"]
                  [prismatic/schema "1.2.1"]
-                 [net.clojars.macielti/common-clj "13.16.12"]]
+                 [net.clojars.macielti/common-clj "14.16.13"]]
 
   :resource-paths ["resources" "test/resources/"]
 

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [com.datomic/datomic-free "0.9.5697"]
                  [nubank/matcher-combinators "3.5.0"]
                  [prismatic/schema "1.2.1"]
-                 [net.clojars.macielti/common-clj "14.16.13"]]
+                 [net.clojars.macielti/common-clj "14.16.14"]]
 
   :resource-paths ["resources" "test/resources/"]
 

--- a/resources/config.example.edn
+++ b/resources/config.example.edn
@@ -3,6 +3,6 @@
         :bootstrap-server               "http://localhost:9092"
         :service-name                   "wraith-king"
         :password-reset-expiration-days 1
-        :topics                         []
+        :topics                         ["create-dead-letter"]
         :service                        {:host "0.0.0.0"
                                          :port 8010}}}

--- a/src/wraith_king/adapters/dead_letter.clj
+++ b/src/wraith_king/adapters/dead_letter.clj
@@ -8,7 +8,7 @@
 
 (s/defn wire->dead-letter :- models.dead-letter/DeadLetter
   [{:keys [service topic exceptionInfo payload]} :- wire.in.dead-letter/DeadLetter]
-  {:dead-letter/id             (UUID/randomUUID)
+  {:dead-letter/id             (UUID/nameUUIDFromBytes (.getBytes (str service topic exceptionInfo payload)))
    :dead-letter/service        (camel-snake-kebab/->kebab-case-keyword service)
    :dead-letter/topic          (camel-snake-kebab/->kebab-case-keyword topic)
    :dead-letter/exception-info exceptionInfo

--- a/src/wraith_king/components.clj
+++ b/src/wraith_king/components.clj
@@ -5,6 +5,7 @@
             [common-clj.component.routes :as component.routes]
             [common-clj.component.service :as component.service]
             [common-clj.component.kafka.consumer :as component.consumer]
+            [common-clj.component.kafka.producer :as component.producer]
             [wraith-king.db.datomic.config :as datomic.config]
             [wraith-king.diplomat.http-server :as diplomat.http-server]
             [wraith-king.diplomat.consumer :as diplomat.consumer]))
@@ -16,7 +17,8 @@
     :datomic (component/using (component.datomic/new-datomic datomic.config/schemas) [:config])
     :routes (component/using (component.routes/new-routes diplomat.http-server/routes) [:datomic :config])
     :consumer (component/using (component.consumer/new-consumer diplomat.consumer/consumers) [:config :datomic])
-    :service (component/using (common-clj.component.service/new-service) [:routes :datomic :config])))
+    :producer (component/using (component.producer/new-producer) [:config])
+    :service (component/using (common-clj.component.service/new-service) [:routes :datomic :producer :config])))
 
 (defn start-system! []
   (component/start system))
@@ -27,4 +29,5 @@
     :datomic (component/using (component.datomic/new-datomic datomic.config/schemas) [:config])
     :routes (component/using (component.routes/new-routes diplomat.http-server/routes) [:datomic :config])
     :consumer (component/using (component.consumer/new-mock-consumer diplomat.consumer/consumers) [:config :datomic])
-    :service (component/using (component.service/new-service) [:routes :datomic :config])))
+    :producer (component/using (component.producer/new-mock-producer) [:consumer :config])
+    :service (component/using (component.service/new-service) [:routes :datomic :producer :config])))

--- a/src/wraith_king/components.clj
+++ b/src/wraith_king/components.clj
@@ -4,6 +4,7 @@
             [common-clj.component.datomic :as component.datomic]
             [common-clj.component.routes :as component.routes]
             [common-clj.component.service :as component.service]
+            [common-clj.component.kafka.consumer :as component.consumer]
             [wraith-king.db.datomic.config :as datomic.config]
             [wraith-king.diplomat.http-server :as diplomat.http-server]))
 
@@ -13,6 +14,7 @@
     :config (component.config/new-config "resources/config.edn" :prod :edn)
     :datomic (component/using (component.datomic/new-datomic datomic.config/schemas) [:config])
     :routes (component/using (component.routes/new-routes diplomat.http-server/routes) [:datomic :config])
+    :consumer (component/using (component.consumer/new-consumer diplomat.consumer/consumers) [:config :datomic])
     :service (component/using (common-clj.component.service/new-service) [:routes :datomic :config])))
 
 (defn start-system! []
@@ -23,4 +25,5 @@
     :config (component.config/new-config "resources/config.example.edn" :test :edn)
     :datomic (component/using (component.datomic/new-datomic datomic.config/schemas) [:config])
     :routes (component/using (component.routes/new-routes diplomat.http-server/routes) [:datomic :config])
+    :consumer (component/using (component.consumer/new-mock-consumer diplomat.consumer/consumers) [:config :datomic])
     :service (component/using (component.service/new-service) [:routes :datomic :config])))

--- a/src/wraith_king/components.clj
+++ b/src/wraith_king/components.clj
@@ -6,7 +6,8 @@
             [common-clj.component.service :as component.service]
             [common-clj.component.kafka.consumer :as component.consumer]
             [wraith-king.db.datomic.config :as datomic.config]
-            [wraith-king.diplomat.http-server :as diplomat.http-server]))
+            [wraith-king.diplomat.http-server :as diplomat.http-server]
+            [wraith-king.diplomat.consumer :as diplomat.consumer]))
 
 
 (def system

--- a/src/wraith_king/controllers/dead_letter.clj
+++ b/src/wraith_king/controllers/dead_letter.clj
@@ -7,10 +7,11 @@
 (s/defn create! :- models.dead-letter/DeadLetter
   [{:dead-letter/keys [id] :as dead-letter} :- models.dead-letter/DeadLetter
    datomic]
-  (if (datomic.dead-letter/lookup id datomic)
-    (datomic.dead-letter/mark-as-unprocessed! id datomic)
-    (datomic.dead-letter/insert! dead-letter datomic))
-  dead-letter)
+  (if (= :processed (-> (datomic.dead-letter/lookup id datomic) :dead-letter/status))
+    (do (datomic.dead-letter/mark-as-unprocessed! id datomic)
+        (datomic.dead-letter/lookup id datomic))
+    (do (datomic.dead-letter/insert! dead-letter datomic)
+        dead-letter)))
 
 (s/defn fetch :- (s/maybe models.dead-letter/DeadLetter)
   [dead-letter-id :- s/Uuid

--- a/src/wraith_king/controllers/dead_letter.clj
+++ b/src/wraith_king/controllers/dead_letter.clj
@@ -1,12 +1,15 @@
 (ns wraith-king.controllers.dead-letter
   (:require [schema.core :as s]
             [wraith-king.models.dead-letter :as models.dead-letter]
-            [wraith-king.db.datomic.dead-letter :as datomic.dead-letter]))
+            [wraith-king.db.datomic.dead-letter :as datomic.dead-letter]
+            [wraith-king.diplomat.producer :as diplomat.producer]))
 
 (s/defn create! :- models.dead-letter/DeadLetter
-  [dead-letter :- models.dead-letter/DeadLetter
+  [{:dead-letter/keys [id] :as dead-letter} :- models.dead-letter/DeadLetter
    datomic]
-  (datomic.dead-letter/insert! dead-letter datomic)
+  (if (datomic.dead-letter/lookup id datomic)
+    (datomic.dead-letter/mark-as-unprocessed! id datomic)
+    (datomic.dead-letter/insert! dead-letter datomic))
   dead-letter)
 
 (s/defn fetch :- (s/maybe models.dead-letter/DeadLetter)
@@ -23,3 +26,11 @@
    datomic]
   (datomic.dead-letter/mark-as-dropped! dead-letter-id datomic)
   (datomic.dead-letter/lookup dead-letter-id datomic))
+
+(s/defn replay!
+  [dead-letter-id :- s/Uuid
+   datomic
+   producer]
+  (let [dead-letter (datomic.dead-letter/lookup dead-letter-id datomic)]
+    (datomic.dead-letter/mask-as-processed! dead-letter datomic)
+    (diplomat.producer/replay-dead-letter! dead-letter producer)))

--- a/src/wraith_king/diplomat/consumer.clj
+++ b/src/wraith_king/diplomat/consumer.clj
@@ -1,0 +1,15 @@
+(ns wraith-king.diplomat.consumer
+  (:require [schema.core :as s]
+            [wraith-king.wire.in.dead-letter :as wire.in.dead-letter]
+            [wraith-king.adapters.dead-letter :as adapters.dead-letter]
+            [wraith-king.controllers.dead-letter :as controllers.dead-letter]))
+
+(s/defn create-dead-letter!
+  [dead-letter
+   {:keys [datomic]}]
+  (-> (adapters.dead-letter/wire->dead-letter dead-letter)
+      (controllers.dead-letter/create! (:connection datomic))))
+
+(def consumers
+  {:create-dead-letter {:schema  wire.in.dead-letter/DeadLetter
+                        :handler create-dead-letter!}})

--- a/src/wraith_king/diplomat/http_server.clj
+++ b/src/wraith_king/diplomat/http_server.clj
@@ -11,6 +11,9 @@
              ["/api/dead-letters/:id" :get [interceptors.user-identity/user-identity-interceptor
                                             (interceptors.user-identity/user-required-roles-interceptor [:admin])
                                             diplomat.http-server.dead-letter/fetch] :route-name :fetch-dead-letter-by-id]
+             ["/api/dead-letters/:id" :post [interceptors.user-identity/user-identity-interceptor
+                                             (interceptors.user-identity/user-required-roles-interceptor [:admin])
+                                             diplomat.http-server.dead-letter/replay!] :route-name :replay-dead-letter-by-id]
              ["/api/dead-letters/:id" :delete [interceptors.user-identity/user-identity-interceptor
                                                (interceptors.user-identity/user-required-roles-interceptor [:admin])
                                                diplomat.http-server.dead-letter/drop!] :route-name :drop-dead-letter]])

--- a/src/wraith_king/diplomat/http_server/dead_letter.clj
+++ b/src/wraith_king/diplomat/http_server/dead_letter.clj
@@ -37,3 +37,9 @@
    :body   (-> (UUID/fromString id)
                (controllers.dead-letter/drop! (:connection datomic))
                adapters.dead-letter/->wire)})
+
+(s/defn replay!
+  [{{:keys [id]}               :path-params
+    {:keys [datomic producer]} :components}]
+  (controllers.dead-letter/replay! (UUID/fromString id) (:connection datomic) producer)
+  {:status 202})

--- a/src/wraith_king/diplomat/producer.clj
+++ b/src/wraith_king/diplomat/producer.clj
@@ -1,0 +1,12 @@
+(ns wraith-king.diplomat.producer
+  (:require [common-clj.component.kafka.producer :as kafka.producer]
+            [wraith-king.models.dead-letter :as models.dead-letter]
+            [schema.core :as s]
+            [cheshire.core :as json]))
+
+(s/defn replay-dead-letter!
+  [{:dead-letter/keys [topic payload]} :- models.dead-letter/DeadLetter
+   producer]
+  (kafka.producer/produce! {:topic topic
+                            :data  {:payload (json/decode payload true)}}
+                           producer))

--- a/src/wraith_king/wire/in/dead_letter.clj
+++ b/src/wraith_king/wire/in/dead_letter.clj
@@ -2,7 +2,7 @@
   (:require [schema.core :as s]))
 
 (s/defschema DeadLetter
-  {:service        s/Str
-   :topic          s/Str
+  {:service       s/Str
+   :topic         s/Str
    :exceptionInfo s/Str
-   :payload        s/Str})
+   :payload       s/Str})

--- a/test/integration/integration/aux/http.clj
+++ b/test/integration/integration/aux/http.clj
@@ -52,3 +52,14 @@
      :body   (if (= status 200)
                (json/decode body true)
                body)}))
+
+(defn replay-dead-letter!
+  [dead-letter-id
+   token
+   service-fn]
+  (let [{:keys [body status]} (test/response-for service-fn
+                                                 :post (str "/api/dead-letters/" dead-letter-id)
+                                                 :headers {"Content-Type"  "application/json"
+                                                           "Authorization" (str "Bearer " token)})]
+    {:status status
+     :body   (json/decode body true)}))

--- a/test/integration/integration/create_dead_letter.clj
+++ b/test/integration/integration/create_dead_letter.clj
@@ -13,7 +13,8 @@
 (deftest create-dead-letter
   (let [system (component/start components/system-test)
         service-fn (:io.pedestal.http/service-fn (component.helper/get-component-content :service system))
-        {:keys [jwt-secret]} (component.helper/get-component-content :config system)]
+        {:keys [jwt-secret]} (component.helper/get-component-content :config system)
+        token (common-auth/->token fixtures.user/user-info jwt-secret)]
 
     (testing "that we can create a endpoint using a dead-letter"
       (is (match? {:status 201
@@ -27,10 +28,14 @@
                             :updated-at     string?
                             :created-at     string?}}
                   (http/create-dead-letter! fixtures.dead-letter/wire-dead-letter
-                                            (common-auth/->token fixtures.user/user-info jwt-secret)
+                                            token
                                             service-fn)))
 
-      (testing "that creating the same dead-letter two times, only increase the replay count of the first one"
+      (testing "that creating the same dead-letter two times, only increase the replay count of the first one if it was in a processed status"
+        (http/replay-dead-letter! (-> (http/fetch-active-dead-letters token service-fn) :body first :id)
+                                  token
+                                  service-fn)
+
         (is (match? {:status 201
                      :body   {:service        "PORTEIRO"
                               :payload        "{\"test\": \"ok\"}"
@@ -42,6 +47,6 @@
                               :updated-at     string?
                               :created-at     string?}}
                     (http/create-dead-letter! fixtures.dead-letter/wire-dead-letter
-                                              (common-auth/->token fixtures.user/user-info jwt-secret)
+                                              token
                                               service-fn)))))
     (component/stop system)))

--- a/test/integration/integration/create_dead_letter.clj
+++ b/test/integration/integration/create_dead_letter.clj
@@ -14,6 +14,7 @@
   (let [system (component/start components/system-test)
         service-fn (:io.pedestal.http/service-fn (component.helper/get-component-content :service system))
         {:keys [jwt-secret]} (component.helper/get-component-content :config system)]
+
     (testing "that we can create a endpoint using a dead-letter"
       (is (match? {:status 201
                    :body   {:service        "PORTEIRO"
@@ -27,5 +28,20 @@
                             :created-at     string?}}
                   (http/create-dead-letter! fixtures.dead-letter/wire-dead-letter
                                             (common-auth/->token fixtures.user/user-info jwt-secret)
-                                            service-fn))))
+                                            service-fn)))
+
+      (testing "that creating the same dead-letter two times, only increase the replay count of the first one"
+        (is (match? {:status 201
+                     :body   {:service        "PORTEIRO"
+                              :payload        "{\"test\": \"ok\"}"
+                              :topic          "SOME_TOPIC"
+                              :status         "UNPROCESSED"
+                              :id             clj-uuid/uuid-string?
+                              :replay-count   1
+                              :exception-info "Critical Exception (StackTrace)"
+                              :updated-at     string?
+                              :created-at     string?}}
+                    (http/create-dead-letter! fixtures.dead-letter/wire-dead-letter
+                                              (common-auth/->token fixtures.user/user-info jwt-secret)
+                                              service-fn)))))
     (component/stop system)))

--- a/test/integration/integration/drop_dead_letter.clj
+++ b/test/integration/integration/drop_dead_letter.clj
@@ -8,8 +8,7 @@
             [matcher-combinators.test :refer [match?]]
             [clj-uuid]
             [fixtures.user]
-            [fixtures.dead-letter]
-            [taoensso.timbre :as log]))
+            [fixtures.dead-letter]))
 
 
 (deftest create-dead-letter

--- a/test/integration/integration/replay_dead_letter.clj
+++ b/test/integration/integration/replay_dead_letter.clj
@@ -1,0 +1,30 @@
+(ns integration.replay-dead-letter
+  (:require [clojure.test :refer :all]
+            [com.stuartsierra.component :as component]
+            [wraith-king.components :as components]
+            [common-clj.component.helper.core :as component.helper]
+            [integration.aux.http :as http]
+            [common-clj.auth.core :as common-auth]
+            [matcher-combinators.test :refer [match?]]
+            [fixtures.dead-letter]
+            [fixtures.user]
+            [common-clj.component.kafka.consumer :as component.consumer]))
+
+(deftest create-dead-letter
+  (let [system (component/start components/system-test)
+        consumer (component.helper/get-component-content :consumer system)
+        service-fn (:io.pedestal.http/service-fn (component.helper/get-component-content :service system))
+        {:keys [jwt-secret]} (component.helper/get-component-content :config system)
+        token (common-auth/->token fixtures.user/user-info jwt-secret)]
+
+    (testing "that we can replay a dead-letter by it's id"
+      (is (match? {:status 202}
+                  (http/replay-dead-letter! (-> (http/create-dead-letter! fixtures.dead-letter/wire-dead-letter token service-fn) :body :id)
+                                            token
+                                            service-fn)))
+
+      (testing "that when we replay a dead-letter, the message is reproduced"
+        (is (match? [{:topic :some-topic
+                      :data  {:payload {:test "ok"}}}]
+                    (component.consumer/produced-messages consumer)))))
+    (component/stop system)))

--- a/test/unit/wraith_king/adapters/dead_letter_test.clj
+++ b/test/unit/wraith_king/adapters/dead_letter_test.clj
@@ -17,6 +17,10 @@
                  :dead-letter/status         :unprocessed
                  :dead-letter/topic          :some-topic
                  :dead-letter/payload        "{\"test\": \"ok\"}"}
+                (adapters.dead-letter/wire->dead-letter fixtures.dead-letter/wire-dead-letter))))
+
+  (testing "the same wire dead-letter input always produce dead-letters with the same id"
+    (is (match? {:dead-letter/id #uuid "eba6c1aa-9409-3a5d-ab2f-b4a4cc5b14b8"}
                 (adapters.dead-letter/wire->dead-letter fixtures.dead-letter/wire-dead-letter)))))
 
 (st/deftest ->wire-test


### PR DESCRIPTION
- Add consumer for creating dead-letters via Kafka messages.
  - Be able to identify already created dead-letter. 
- Add endpoint to replay dead letters by it's id.